### PR TITLE
fix int type vertex attributes in gl450

### DIFF
--- a/renoir-gl450/src/renoir-gl450/Renoir-gl450.cpp
+++ b/renoir-gl450/src/renoir-gl450/Renoir-gl450.cpp
@@ -564,6 +564,22 @@ _renoir_type_normalized(RENOIR_TYPE type)
 	}
 }
 
+inline static bool
+_renoir_type_is_int(RENOIR_TYPE type)
+{
+	switch(type)
+	{
+	case RENOIR_TYPE_UINT8:
+	case RENOIR_TYPE_UINT8_4:
+	case RENOIR_TYPE_UINT16:
+	case RENOIR_TYPE_UINT32:
+	case RENOIR_TYPE_INT16:
+	case RENOIR_TYPE_INT32:
+		return true;
+	default: return false;
+	}
+}
+
 inline static GLenum
 _renoir_min_filter_to_gl(RENOIR_FILTER filter)
 {
@@ -2721,15 +2737,29 @@ _renoir_gl450_command_execute(IRenoir* self, Renoir_Command* command)
 
 			GLint gl_size = _renoir_type_to_gl_element_count(vertex.type);
 			GLenum gl_type = _renoir_type_to_gl(vertex.type);
-			bool gl_normalized = _renoir_type_normalized(vertex.type);
-			glVertexAttribPointer(
-				GLuint(i),
-				gl_size,
-				gl_type,
-				gl_normalized,
-				vertex.stride,
-				(void*)vertex.offset
-			);
+
+			if (_renoir_type_is_int(vertex.type))
+			{
+				glVertexAttribIPointer(
+					GLuint(i),
+					gl_size,
+					gl_type,
+					vertex.stride,
+					(void*)vertex.offset
+				);
+			}
+			else
+			{
+				bool gl_normalized = _renoir_type_normalized(vertex.type);
+				glVertexAttribPointer(
+					GLuint(i),
+					gl_size,
+					gl_type,
+					gl_normalized,
+					vertex.stride,
+					(void*)vertex.offset
+				);
+			}
 			glEnableVertexAttribArray(i);
 		}
 


### PR DESCRIPTION
when we have a vertex attribute that has an integer type GLSL casts them to float
![image](https://user-images.githubusercontent.com/23073817/113508938-2295d100-9553-11eb-971f-ec2efbb1e4d9.png)
after investigating the problem, we found that we should use `glVertexAttribIPointer` if want type to be integer in the shader and to have the same effect as directX. qouted from this [link](https://community.khronos.org/t/vertex-shader-integer-input-broken/72878/2).

> glVertexAttribPointer( 0, 3, GL_FLOAT, GL_FALSE, 16, pointer );
> glVertexAttribPointer( 1, 1, GL_INT, GL_FALSE, 16, pointer+12 );
> This defines a vec3 and int input attribute.[/quote]
> 
> No, it does not. It defines two floating-point vertex shader inputs, one of which is stored in the buffer object as 3 floats, and the other of which is stored as 1 non-normalized 32-bit signed integer.
> 
> If you want to specify a vertex attribute 28 that connects to an actual integer in GLSL, you must use glVertexAttribIPointer. Note the “I” present before “Pointer”. That means you’re specifying data that will be retrieved in GLSL by an integer variable (signed or unsigned).
> 
> If you’re wondering why OpenGL makes you specify redundant information, it doesn’t. What this does is let you specify that a floating-point input in GLSL comes from normalized or non-normalized integer data in your VBO. It’s a way of doing compression. For example, it allows you to store the 4 components of a color as normalized, unsigned bytes, using only 4 bytes that feeds an entire “vec4” in GLSL.

note that if we added any 64 type in the future (double for example) we will need to use `glVertexAttribLPointer` for it.